### PR TITLE
CATS-2155 | Disable spellcheck due to Chrome perf regression

### DIFF
--- a/src/ce/nodes/ve.ce.ContentEditableNode.js
+++ b/src/ce/nodes/ve.ce.ContentEditableNode.js
@@ -72,7 +72,8 @@ ve.ce.ContentEditableNode.prototype.onSurfaceReadOnly = function ( readOnly ) {
  * @param {boolean} readOnly Surface is read-only
  */
 ve.ce.ContentEditableNode.prototype.setReadOnly = function ( readOnly ) {
-	this.$element.prop( 'spellcheck', !readOnly );
+	// Fandom change: Disable spellcheck due to Chromium bug 1271918 (CATS-2155)
+	this.$element.prop( 'spellcheck', false /* !readOnly */ );
 };
 
 /**


### PR DESCRIPTION
Disable spellchecking in VE due to https://bugs.chromium.org/p/chromium/issues/detail?id=1271918