### PR TITLE
UGC-4682 | Fix IME input (New Windows IME for Japanese etc.)

### DIFF
--- a/src/ce/ve.ce.Surface.js
+++ b/src/ce/ve.ce.Surface.js
@@ -3140,6 +3140,7 @@ ve.ce.Surface.prototype.onDocumentBeforeInput = function ( e ) {
 
 		var selectionState = new ve.SelectionState( this.nativeSelection );
 
+		// Fixes issue with deleting Carriage Return in Android with GBoard
 		if ( inputType === 'deleteContentBackward' &&
 			selectionState.anchorOffset === 1 &&
 			selectionState.focusOffset === 0

--- a/src/ce/ve.ce.Surface.js
+++ b/src/ce/ve.ce.Surface.js
@@ -3138,7 +3138,12 @@ ve.ce.Surface.prototype.onDocumentBeforeInput = function ( e ) {
 		var surface = this,
 			inputType = e.originalEvent ? e.originalEvent.inputType : null;
 
-		if ( inputType === 'deleteContentBackward' ) {
+		var selectionState = new ve.SelectionState( this.nativeSelection );
+
+		if ( inputType === 'deleteContentBackward' &&
+			selectionState.anchorOffset === 1 &&
+			selectionState.focusOffset === 0
+		) {
 			this.surfaceObserver.pollOnce();
 			ve.ce.keyDownHandlerFactory.lookup( 'linearDelete' ).static.execute( this, e );
 		}


### PR DESCRIPTION
## Links
* https://fandom.atlassian.net/browse/UGC-4682
* https://github.com/Wikia/unified-platform/pull/15839
* https://github.com/Wikia/mediawiki-extensions-VisualEditor/pull/25

## Description
- Make fix for deleteContentBackward event work only for start of line

## Acceptance Criteria
- [ ] test for new code.

## Who might be interested