### PR TITLE
[1.43] PLATFORM-9834: Fix variable assignment

### DIFF
--- a/src/ce/ve.ce.Surface.js
+++ b/src/ce/ve.ce.Surface.js
@@ -2385,7 +2385,7 @@ ve.ce.Surface.prototype.onDocumentInput = function ( e ) {
 	if ( inputType === 'deleteContentBackward' || inputType === 'insertCompositionText' ) {
 		this.deleteContentBackwardSelectionState = new ve.SelectionState( this.nativeSelection );
 		setTimeout( function () {
-			surface.deleteContentBackwardSelectionState = null;
+			this.deleteContentBackwardSelectionState = null;
 		} );
 	}
 


### PR DESCRIPTION
## Links
* https://fandom.atlassian.net/browse/PLATFORM-9834
* https://github.com/Wikia/unified-platform/pull/19302
* https://github.com/Wikia/mediawiki-extensions-CodeMirror/pull/32
* https://github.com/Wikia/VisualEditor/pull/7 - fix of variable
* https://github.com/Wikia/mediawiki-extensions-VisualEditor/pull/30 - update submodule of above
* https://github.com/Wikia/mediawiki-extensions-WikiEditor/pull/6

## Description
Fixed assignment to `deleteContentBackwardSelectionState` as surface is now not available anymore